### PR TITLE
Add archiver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,4 @@ gem "nokogiri"
 gem "open-uri-cached"
 gem "fuzzy_match"
 gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'
+gem 'scraped_page_archive', git: 'https://github.com/everypolitician/scraped_page_archive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/everypolitician/scraped_page_archive
+  revision: 9d8a6347d122d42a983ba28ff84d24de6bdca8a0
+  specs:
+    scraped_page_archive (0.4.1)
+      git (~> 1.3.0)
+      vcr-archive (~> 0.3.0)
+
+GIT
   remote: https://github.com/openaustralia/scraperwiki-ruby.git
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
@@ -10,8 +18,11 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.4.0)
     coderay (1.1.0)
     colorize (0.7.7)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     excon (0.45.4)
     execjs (2.5.2)
     faraday (0.9.1)
@@ -19,6 +30,8 @@ GEM
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
     fuzzy_match (2.1.0)
+    git (1.3.0)
+    hashdiff (0.3.0)
     hashie (3.4.2)
     httpclient (2.6.0.1)
     method_source (0.8.2)
@@ -31,10 +44,19 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    safe_yaml (1.0.4)
     slop (3.6.0)
     sqlite3 (1.3.10)
     sqlite_magic (0.0.3)
       sqlite3
+    vcr (3.0.3)
+    vcr-archive (0.3.0)
+      vcr (~> 3.0.2)
+      webmock (~> 2.0.3)
+    webmock (2.0.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     wikidata-client (0.0.7)
       excon (~> 0.40)
       faraday (~> 0.9)
@@ -51,5 +73,6 @@ DEPENDENCIES
   nokogiri
   open-uri-cached
   pry
+  scraped_page_archive!
   scraperwiki!
   wikidata-client (~> 0.0.7)

--- a/scraper.rb
+++ b/scraper.rb
@@ -8,8 +8,9 @@ require 'open-uri'
 
 # require 'colorize'
 require 'pry'
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
+# require 'open-uri/cached'
+# OpenURI::Cache.cache_path = '.cache'
+require 'scraped_page_archive/open-uri'
 
 def noko_for(url)
   Nokogiri::HTML(open(url).read)


### PR DESCRIPTION
The scraped page archive was added to the Gemfile

The `MORPH_SCRAPER_CACHE_GITHUB_REPO_URL` environment variable has to be added to the scraper in morph or wait until we move it to EP-scrapers and add it ourselves.

https://morph.io/tmtmtmtm/pakistan-national-assembly/settings
